### PR TITLE
remove docs mention in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,9 +8,7 @@ body:
       value: |
         Thank you for taking the time to report a bug with this library.
 
-        Before you submit an issue, please ensure that you have done the following.
-          - Read the [documentation](https://github.com/james-elicx/package-manager-manager/tree/main/docs).
-          - Searched for existing issues.
+        Before you submit an issue, please ensure that you have searched for it in the existing issues.
 
         To help us address your issue as quickly as possible, please fill out the following information.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,9 +8,7 @@ body:
       value: |
         Thank you for taking the time to file a feature request.
 
-        Before you submit an issue, please ensure that you have done the following.
-          - Read the [documentation](https://github.com/james-elicx/package-manager-manager/tree/main/docs).
-          - Searched for existing feature requests.
+        Before you submit an issue, please ensure that you have searched for it in the existing issues.
 
         To increase the chance of your feature request being accepted, please provide as much information as possible.
 


### PR DESCRIPTION
The [link to the docs](https://github.com/james-elicx/package-manager-manager/tree/main/docs) results in a 404, so (at least for now) I think it makes sense to just remove the line that mentions it