### PR TITLE
fix pnpm broken getPackageInfo

### DIFF
--- a/src/package/shared.ts
+++ b/src/package/shared.ts
@@ -18,11 +18,12 @@ export function getNpmOrPnpmGetPackageInfoFunction(
 ) {
 	return async (...[name]: Parameters<GetPackageInfo>): ReturnType<GetPackageInfo> => {
 		try {
-			const outputJson: NpmListOutputJson = JSON.parse(
+			const outputJson = JSON.parse(
 				(await shellac`$ ${packageManager} list --depth=0 --json`).stdout,
 			);
 
-			const packageInfo = outputJson.dependencies[name];
+			const info: NpmListOutputJson = packageManager === 'npm' ? outputJson : outputJson[0];
+			const packageInfo = info.dependencies[name];
 
 			if (!packageInfo) {
 				return null;


### PR DESCRIPTION
sorry my bad! :pray: :sweat: 

I thought that npm and pnpm were the same but they're actually slightly different :sweat: 

![npm info](https://github.com/james-elicx/package-manager-manager/assets/61631103/68fabdf2-8604-4b8c-834b-72658eb6f62f)

![pnpm info](https://github.com/james-elicx/package-manager-manager/assets/61631103/b3c5d19a-3d2a-4841-9b2f-596d248139d9)
