### PR TITLE
try-catch package manager version detection

### DIFF
--- a/.changeset/large-files-complain.md
+++ b/.changeset/large-files-complain.md
@@ -1,0 +1,5 @@
+---
+'package-manager-manager': patch
+---
+
+set packageManager version to null in case the version detection fails

--- a/src/commands/getRunExec.ts
+++ b/src/commands/getRunExec.ts
@@ -74,7 +74,7 @@ class RunExecStruct implements CommandExecStruct {
 			case 'npm':
 				return format === 'short' ? { cmd: 'npx' } : { cmd: 'npm', pmCmd: 'exec' };
 			case 'yarn':
-				if (packageManager.version.startsWith('1.')) {
+				if (isYarnClassic(packageManager)) {
 					// yarn classic doesn't have dlx
 					return { cmd: 'yarn', pmCmd: 'exec' };
 				}

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -71,7 +71,7 @@ async function getPackageManagerVersion(
 	packageManager: PackageManagerName,
 ): Promise<string | null> {
 	try {
-		const { stdout } = await shellac`$ ${packageManager} --version `;
+		const { stdout } = await shellac`$ ${packageManager} --version`;
 		return stdout;
 	} catch {
 		return null;

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -71,7 +71,7 @@ async function getPackageManagerVersion(
 	packageManager: PackageManagerName,
 ): Promise<string | null> {
 	try {
-		const { stdout } = await shellac`$ ${packageManager} --version`;
+		const { stdout } = await shellac`$ ${packageManager} --version `;
 		return stdout;
 	} catch {
 		return null;

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -18,7 +18,7 @@ export type PackageManager = {
 	 * project set up using `pnpm`) */
 	projectPackageManager: PackageManagerName | null;
 	/** The version of the package manager */
-	version: string;
+	version: string | null;
 	/**
 	 * Utility to get the information of an installed package
 	 *
@@ -67,9 +67,15 @@ export type PackageManager = {
 	cliCommandKeywords: Set<string>;
 };
 
-async function getPackageManagerVersion(packageManager: PackageManagerName): Promise<string> {
-	const { stdout } = await shellac`$ ${packageManager} --version`;
-	return stdout;
+async function getPackageManagerVersion(
+	packageManager: PackageManagerName,
+): Promise<string | null> {
+	try {
+		const { stdout } = await shellac`$ ${packageManager} --version`;
+		return stdout;
+	} catch {
+		return null;
+	}
 }
 
 /**

--- a/src/utils/yarn.ts
+++ b/src/utils/yarn.ts
@@ -1,5 +1,5 @@
 import type { PackageManager } from '../packageManager';
 
 export function isYarnClassic(packageManager: Pick<PackageManager, 'name' | 'version'>): boolean {
-	return packageManager.name === 'yarn' && packageManager.version.startsWith('1.');
+	return !!(packageManager.name === 'yarn' && packageManager.version?.startsWith('1.'));
 }


### PR DESCRIPTION
> **Warning**
> IMPORTANT: I don't think this is the proper solution, we'd need to understand why the version detection is failing on the Cloudflare Pages CI, but this should be a temporary patch that can at least make builds succeed