### PR TITLE
Properly fix pm version detection failing in the Cloudflare Pages CI

### DIFF
--- a/.changeset/silver-carpets-jump.md
+++ b/.changeset/silver-carpets-jump.md
@@ -1,0 +1,5 @@
+---
+'package-manager-manager': patch
+---
+
+properly fix pm version detection failing in the Cloudflare Pages CI

--- a/package.json
+++ b/package.json
@@ -65,5 +65,10 @@
 	"dependencies": {
 		"js-yaml": "^4.1.0",
 		"shellac": "^0.8.0"
+	},
+	"pnpm": {
+		"patchedDependencies": {
+			"shellac@0.8.0": "patches/shellac@0.8.0.patch"
+		}
 	}
 }

--- a/patches/shellac@0.8.0.patch
+++ b/patches/shellac@0.8.0.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index 2dba4e1ef63990afd2fed5ab76f5f73474636b75..5d65190f6e049196c61c8668cb985bad58e4d882 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -1012,7 +1012,7 @@ function makeShellac(cwd = process.cwd(), env = {}, shell = lazyCreateShell) {
+     }
+   });
+ }
+-var shellac = makeShellac();
++var shellac = makeShellac(undefined, process.env);
+ var src_default = shellac;
+ // Annotate the CommonJS export names for ESM import in node:
+ 0 && (module.exports = {});
+diff --git a/dist/index.js b/dist/index.js
+index 5b74396bf323b2319e9e13827bf237f41f0ee126..5e45411edc2b8ea472fe9ed47df1a9ef94fc2207 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -986,7 +986,7 @@ function makeShellac(cwd = process.cwd(), env = {}, shell = lazyCreateShell) {
+     }
+   });
+ }
+-var shellac = makeShellac();
++var shellac = makeShellac(undefined, process.env);
+ var src_default = shellac;
+ export {
+   src_default as default

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,17 @@
 lockfileVersion: '6.0'
 
+patchedDependencies:
+  shellac@0.8.0:
+    hash: dcb37gsmyfv6thxiyzmoqs2fvu
+    path: patches/shellac@0.8.0.patch
+
 dependencies:
   js-yaml:
     specifier: ^4.1.0
     version: 4.1.0
   shellac:
     specifier: ^0.8.0
-    version: 0.8.0
+    version: 0.8.0(patch_hash=dcb37gsmyfv6thxiyzmoqs2fvu)
 
 devDependencies:
   '@changesets/cli':
@@ -3484,11 +3489,12 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /shellac@0.8.0:
+  /shellac@0.8.0(patch_hash=dcb37gsmyfv6thxiyzmoqs2fvu):
     resolution: {integrity: sha512-M3F2vzYIM7frKOs0+kgs/ITMlXhGpgtqs9HxDPciz3bckzAqqfd4LrBn+CCmSbICyJS+Jz5UDkmkR1jE+m+g+Q==}
     dependencies:
       reghex: 1.0.2
     dev: false
+    patched: true
 
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}

--- a/src/commands/getRunExec.ts
+++ b/src/commands/getRunExec.ts
@@ -74,7 +74,7 @@ class RunExecStruct implements CommandExecStruct {
 			case 'npm':
 				return format === 'short' ? { cmd: 'npx' } : { cmd: 'npm', pmCmd: 'exec' };
 			case 'yarn':
-				if (isYarnClassic(packageManager)) {
+				if (packageManager.version.startsWith('1.')) {
 					// yarn classic doesn't have dlx
 					return { cmd: 'yarn', pmCmd: 'exec' };
 				}

--- a/src/commands/getRunExec.ts
+++ b/src/commands/getRunExec.ts
@@ -74,7 +74,7 @@ class RunExecStruct implements CommandExecStruct {
 			case 'npm':
 				return format === 'short' ? { cmd: 'npx' } : { cmd: 'npm', pmCmd: 'exec' };
 			case 'yarn':
-				if (packageManager.version.startsWith('1.')) {
+				if (isYarnClassic(packageManager)) {
 					// yarn classic doesn't have dlx
 					return { cmd: 'yarn', pmCmd: 'exec' };
 				}

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -18,7 +18,7 @@ export type PackageManager = {
 	 * project set up using `pnpm`) */
 	projectPackageManager: PackageManagerName | null;
 	/** The version of the package manager */
-	version: string | null;
+	version: string;
 	/**
 	 * Utility to get the information of an installed package
 	 *
@@ -67,15 +67,9 @@ export type PackageManager = {
 	cliCommandKeywords: Set<string>;
 };
 
-async function getPackageManagerVersion(
-	packageManager: PackageManagerName,
-): Promise<string | null> {
-	try {
-		const { stdout } = await shellac`$ ${packageManager} --version`;
-		return stdout;
-	} catch {
-		return null;
-	}
+async function getPackageManagerVersion(packageManager: PackageManagerName): Promise<string> {
+	const { stdout } = await shellac`$ ${packageManager} --version`;
+	return stdout;
 }
 
 /**

--- a/src/utils/yarn.ts
+++ b/src/utils/yarn.ts
@@ -1,5 +1,5 @@
 import type { PackageManager } from '../packageManager';
 
 export function isYarnClassic(packageManager: Pick<PackageManager, 'name' | 'version'>): boolean {
-	return !!(packageManager.name === 'yarn' && packageManager.version?.startsWith('1.'));
+	return packageManager.name === 'yarn' && packageManager.version.startsWith('1.');
 }


### PR DESCRIPTION
Fixing the fact that `npm --version` doesn't work in the Cloudflare Pages CI by patching the shellac package.

This PR also reverts the hasty changes made in #39 (which should not be necessary)

> **Note**
> I'll open a PR in the [shellac repo](https://github.com/geelen/shellac) to get this fixed in the package itself, but I don't know how long that can take so for now let's simply patch the package (PS: if for whatever reason the change can make it into the shellac package then I would suggest switching to a different package for running shell scripts)