### PR TITLE
Add `npm_run` and `npx` utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The main API of the library is based on a `PackageManager` which you simply can 
 Once you have a `PackageManager` object its API should be easily explorable via your IDE intellisense (thanks to the fact that this library comes with properly defined and documented typescript types).
 
 #### Example
+
 ```js
 const packageManager = await getPackageManager();
 
@@ -139,20 +140,20 @@ There are two methods that can be used to generate script and exec-like commands
 The function parses the provided string and generates its equivalent for the current package manager.
 
 #### Example
-```ts
- import { npm_run } from 'package-manager-manager';
 
- const myScriptRun = await npm_run` my-script -- --local`;
- console.log(myScriptRun);
- // based on what the current package manager is it prints:
- //  - `npm run my-script -- --local` for npm
- //  - `yarn my-script --local` for yarn
- //  - `pnpm my-script --local` for pnpm
- //  - `bun my-script --local` for bun
+```ts
+import { npm_run } from 'package-manager-manager';
+
+const myScriptRun = await npm_run` my-script -- --local`;
+console.log(myScriptRun);
+// based on what the current package manager is it prints:
+//  - `npm run my-script -- --local` for npm
+//  - `yarn my-script --local` for yarn
+//  - `pnpm my-script --local` for pnpm
+//  - `bun my-script --local` for bun
 ```
 
 Note: you can also provide options to the `npm_run` function in the following way: `` npm_run.with(options)`...` ``
-
 
 #### `npx`
 
@@ -161,17 +162,18 @@ Note: you can also provide options to the `npm_run` function in the following wa
 The function parses the provided string and generates its equivalent for the current package manager.
 
 #### Example
-```ts
- import { npx } from 'package-manager-manager';
 
- const myPackageCommandRun = await npx` eslint . --fix`;
- console.log(myPackageCommandRun);
- // based on what the current package manager is it prints:
- //  - `npx eslint . --fix` for npm
- //  - `yarn exec eslint . --fix` for yarn (classic)
- //  - `yarn dlx eslint . --fix` for yarn (berry)
- //  - `pnpm dlx eslint . --fix` for pnpm
- //  - `bunx eslint . --fix` for bun
+```ts
+import { npx } from 'package-manager-manager';
+
+const myPackageCommandRun = await npx` eslint . --fix`;
+console.log(myPackageCommandRun);
+// based on what the current package manager is it prints:
+//  - `npx eslint . --fix` for npm
+//  - `yarn exec eslint . --fix` for yarn (classic)
+//  - `yarn dlx eslint . --fix` for yarn (berry)
+//  - `pnpm dlx eslint . --fix` for pnpm
+//  - `bunx eslint . --fix` for bun
 ```
 
 Note: you can also provide options to the `npx` function in the following way: `` npx.with(options)`...` ``

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ It can be used in CLIs or similar projects which may at some point need to know 
 
 ## Usage
 
+### Install
+
 To use the library first install it in your project, via:
 
 ```sh
@@ -31,8 +33,13 @@ npm i package-manager-manager
 
 (or your package manager's equivalent)
 
-Then simply import and use the `getPackageManager()` function to get an object containing all the information you need regarding the package manager currently being used:
+### PackageManager API
 
+The main API of the library is based on a `PackageManager` which you simply can get a hold of by importing and calling the `getPackageManager()` function.
+
+Once you have a `PackageManager` object its API should be easily explorable via your IDE intellisense (thanks to the fact that this library comes with properly defined and documented typescript types).
+
+#### Example
 ```js
 const packageManager = await getPackageManager();
 
@@ -43,12 +50,9 @@ console.log(packageManager.version);
 // logs the version of the package manager e.g. '8.11.0'
 ```
 
-> **Note**
-> This library comes with properly defined and documented typescript types, meaning that once you obtain the `PackageManager` object you will be able to easily see what's available on it and get all necessary details directly in your IDE
+Let's see some of the primary methods exposed by a `PackageManager` object:
 
-### API
-
-### getPackageInfo
+#### getPackageInfo
 
 `packageManager.getPackageInfo` allows you to get the information regarding a locally installed package that your client application is using, it can for example be used to make sure your user's application has a certain dependency or to gather and display the package version of such dependency.
 
@@ -66,7 +70,7 @@ if (zodPackage) {
 > **Note**
 > This method only returns the information of a **locally installed package**, or _null_ in case the package is not installed, it does not return information of packages not locally installed (the API could be extended in the future to also include such use case)
 
-### getRunScript
+#### getRunScript
 
 `packageManager.getRunScript` let's you create a command that can be used to run a script defined in the package.json file.
 
@@ -95,7 +99,7 @@ const buildCmd = packageManager.getRunScriptStruct('build', {
 spawn(buildCmd.cmd, buildCmd.cmdArgs);
 ```
 
-### getRunExec
+#### getRunExec
 
 `packageManager.getRunExec` let's you create a command that can be used to execute a command from a target package (which may or may not be locally installed).
 
@@ -123,3 +127,51 @@ const eslintCmd = packageManager.getRunExec('eslint', {
 // run the command for the user
 spawn(eslintCmd.cmd, eslintCmd.cmdArgs);
 ```
+
+### Short APIs
+
+There are two methods that can be used to generate script and exec-like commands, these are equivalent to respectively `getRunScript` and `getRunExec` but don't require you to manually create a `PackageManager` object (that is done for you under the hood) and provide an API which makes you write code that resembles closer what you'd type in your terminal.
+
+#### `npm_run`
+
+`npm_run` is used to generate a script command, you use it by providing a string literal as its value, the content should be exactly the same as what you'd type in your terminal when using **npm run**, but without the `npm` and `run` keywords.
+
+The function parses the provided string and generates its equivalent for the current package manager.
+
+#### Example
+```ts
+ import { npm_run } from 'package-manager-manager';
+
+ const myScriptRun = await npm_run` my-script -- --local`;
+ console.log(myScriptRun);
+ // based on what the current package manager is it prints:
+ //  - `npm run my-script -- --local` for npm
+ //  - `yarn my-script --local` for yarn
+ //  - `pnpm my-script --local` for pnpm
+ //  - `bun my-script --local` for bun
+```
+
+Note: you can also provide options to the `npm_run` function in the following way: `` npm_run.with(options)`...` ``
+
+
+#### `npx`
+
+`npx` is used to generate an exec-like command, you use it by providing a string literal as its value, the content should be exactly the same as what you'd type in your terminal when using **npx**, but without the `npx` keywords.
+
+The function parses the provided string and generates its equivalent for the current package manager.
+
+#### Example
+```ts
+ import { npx } from 'package-manager-manager';
+
+ const myPackageCommandRun = await npx` eslint . --fix`;
+ console.log(myPackageCommandRun);
+ // based on what the current package manager is it prints:
+ //  - `npx eslint . --fix` for npm
+ //  - `yarn exec eslint . --fix` for yarn (classic)
+ //  - `yarn dlx eslint . --fix` for yarn (berry)
+ //  - `pnpm dlx eslint . --fix` for pnpm
+ //  - `bunx eslint . --fix` for bun
+```
+
+Note: you can also provide options to the `npx` function in the following way: `` npx.with(options)`...` ``

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"@tsconfig/strictest": "^2.0.1",
 		"@types/mock-fs": "^4.13.1",
 		"@types/node": "^20.3.3",
+		"@types/shell-quote": "^1.7.3",
 		"eslint": "^8.44.0",
 		"eslint-config-ixn": "^1.4.2",
 		"eslint-plugin-unicorn": "^48.0.1",
@@ -64,6 +65,7 @@
 	},
 	"dependencies": {
 		"js-yaml": "^4.1.0",
+		"shell-quote": "^1.8.1",
 		"shellac": "^0.8.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ dependencies:
   js-yaml:
     specifier: ^4.1.0
     version: 4.1.0
+  shell-quote:
+    specifier: ^1.8.1
+    version: 1.8.1
   shellac:
     specifier: ^0.8.0
     version: 0.8.0
@@ -21,6 +24,9 @@ devDependencies:
   '@types/node':
     specifier: ^20.3.3
     version: 20.3.3
+  '@types/shell-quote':
+    specifier: ^1.7.3
+    version: 1.7.3
   eslint:
     specifier: ^8.44.0
     version: 8.46.0
@@ -765,6 +771,10 @@ packages:
 
   /@types/semver@7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
+    dev: true
+
+  /@types/shell-quote@1.7.3:
+    resolution: {integrity: sha512-CeYcQaOnluyKPHJTuJmaH9RDJEQSVxGMVf2EZab3chpA8sI65FB19t0x3JlS37NbxL+TUottk9pMypMJQcfhIw==}
     dev: true
 
   /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.46.0)(typescript@5.0.4):
@@ -3483,6 +3493,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
     dev: true
+
+  /shell-quote@1.8.1:
+    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
+    dev: false
 
   /shellac@0.8.0:
     resolution: {integrity: sha512-M3F2vzYIM7frKOs0+kgs/ITMlXhGpgtqs9HxDPciz3bckzAqqfd4LrBn+CCmSbICyJS+Jz5UDkmkR1jE+m+g+Q==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,5 @@ export type { GetRunScriptOptions } from './commands/getRunScript';
 export type { GetRunExecOptions } from './commands/getRunExec';
 
 export type { CommandScriptStruct, CommandExecStruct } from './commands/CommandStruct';
+
+export { npm_run, npx } from './shortFunctions';

--- a/src/shortFunctions/index.ts
+++ b/src/shortFunctions/index.ts
@@ -1,0 +1,2 @@
+export * from './npm_run';
+export * from './npx';

--- a/src/shortFunctions/npm_run.ts
+++ b/src/shortFunctions/npm_run.ts
@@ -1,8 +1,13 @@
 import { parse as shellQuoteParse } from 'shell-quote';
 import type { GetRunScriptOptions } from 'src/commands';
+import type { PackageManager } from '../packageManager';
 import { getPackageManager } from '../packageManager';
 
 type NpmRunOptions = Partial<Omit<GetRunScriptOptions, 'args'>>;
+
+// the current package manager (we use a local variable here to cache it
+// so that it not re-created for each invocation of npm_run)
+let pm: PackageManager | null = null;
 
 function getNpmRunFunction(options: NpmRunOptions = {}) {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -20,7 +25,9 @@ function getNpmRunFunction(options: NpmRunOptions = {}) {
 			return `${accStr}___${value}___${strings[index + 1]}`;
 		}, strings[0]);
 
-		const pm = await getPackageManager();
+		if (!pm) {
+			pm = await getPackageManager();
+		}
 
 		if (!pm) {
 			throw new Error('No package manager!');

--- a/src/shortFunctions/npm_run.ts
+++ b/src/shortFunctions/npm_run.ts
@@ -34,8 +34,8 @@ function getNpmRunFunction(options: NpmRunOptions = {}) {
 			throw new Error('Malformed npm run command (no script provided)');
 		}
 
-		if (doubleDashes !== '--' && scriptArgs.length > 0) {
-			throw new Error('Malformed npm run command (no double dashes before args)');
+		if (doubleDashes && doubleDashes !== '--') {
+			throw new Error('Malformed npm run command (no double dashes provided)');
 		}
 
 		const result = await pm.getRunScript(script, {

--- a/src/shortFunctions/npm_run.ts
+++ b/src/shortFunctions/npm_run.ts
@@ -51,8 +51,15 @@ function getNpmRunFunction(options: NpmRunOptions = {}) {
 	};
 }
 
+/**
+ * Function to generate a script command string for the current package manager.
+ * It accepts all the same arguments that `npm run` does.
+ */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const npm_run = getNpmRunFunction() as ReturnType<typeof getNpmRunFunction> & {
+	/**
+	 * Method used to provide some options to the `npm_run` function.
+	 */
 	with: (options: NpmRunOptions) => ReturnType<typeof getNpmRunFunction>;
 };
 

--- a/src/shortFunctions/npm_run.ts
+++ b/src/shortFunctions/npm_run.ts
@@ -1,0 +1,41 @@
+import { parse as shellQuoteParse } from 'shell-quote';
+import { getPackageManager } from '../packageManager';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export async function npm_run(strings: TemplateStringsArray, ...values: unknown[]): Promise<string>{
+  if(!strings[0]) {
+    throw new Error('Malformed npm run command');
+  }
+
+  // Note: we don't do anything clever with the values (at least for now)
+  // we're using template string literals mainly for the minimalistic api
+  const inputString = values.reduce((accStr: string, value, index) => {
+      return `${accStr}___${value}___${strings[index + 1]}`
+  }, strings[0]);
+
+  const pm = await getPackageManager();
+
+  if(!pm) {
+    throw new Error('No package manager!');
+  }
+
+  const [script, doubleDashes, ...scriptArgs] = shellQuoteParse(inputString).map(e => e.toString());
+
+  if(!script) {
+    throw new Error('Malformed npm run command (no script provided)');
+  }
+
+  if(doubleDashes !== '--' && scriptArgs.length > 0) {
+    throw new Error('Malformed npm run command (no double dashes before args)');
+  }
+
+  const result = await pm.getRunScript(script, {
+    args: scriptArgs
+  });
+
+  if(!result) {
+    throw new Error('Failed to generate the script');
+  }
+
+  return result;
+}

--- a/src/shortFunctions/npm_run.ts
+++ b/src/shortFunctions/npm_run.ts
@@ -1,13 +1,8 @@
 import { parse as shellQuoteParse } from 'shell-quote';
 import type { GetRunScriptOptions } from 'src/commands';
-import type { PackageManager } from '../packageManager';
 import { getPackageManager } from '../packageManager';
 
 type NpmRunOptions = Partial<Omit<GetRunScriptOptions, 'args'>>;
-
-// the current package manager (we use a local variable here to cache it
-// so that it not re-created for each invocation of npm_run)
-let pm: PackageManager | null = null;
 
 function getNpmRunFunction(options: NpmRunOptions = {}) {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -25,9 +20,7 @@ function getNpmRunFunction(options: NpmRunOptions = {}) {
 			return `${accStr}___${value}___${strings[index + 1]}`;
 		}, strings[0]);
 
-		if (!pm) {
-			pm = await getPackageManager();
-		}
+		const pm = await getPackageManager();
 
 		if (!pm) {
 			throw new Error('No package manager!');

--- a/src/shortFunctions/npx.ts
+++ b/src/shortFunctions/npx.ts
@@ -1,8 +1,13 @@
 import { parse as shellQuoteParse } from 'shell-quote';
 import type { GetRunExecOptions } from '../commands';
+import type { PackageManager } from '../packageManager';
 import { getPackageManager } from '../packageManager';
 
 type NpxOptions = Partial<Omit<GetRunExecOptions, 'args'>>;
+
+// the current package manager (we use a local variable here to cache it
+// so that it not re-created for each invocation of npx)
+let pm: PackageManager | null = null;
 
 function getNpxFunction(options: NpxOptions = {}) {
 	return async function npx(strings: TemplateStringsArray, ...values: unknown[]): Promise<string> {
@@ -16,7 +21,9 @@ function getNpxFunction(options: NpxOptions = {}) {
 			return `${accStr}___${value}___${strings[index + 1]}`;
 		}, strings[0]);
 
-		const pm = await getPackageManager();
+		if (!pm) {
+			pm = await getPackageManager();
+		}
 
 		if (!pm) {
 			throw new Error('No package manager!');

--- a/src/shortFunctions/npx.ts
+++ b/src/shortFunctions/npx.ts
@@ -7,7 +7,7 @@ type NpxOptions = Partial<Omit<GetRunExecOptions, 'args'>>;
 function getNpxFunction(options: NpxOptions = {}) {
 	return async function npx(strings: TemplateStringsArray, ...values: unknown[]): Promise<string> {
 		if (!strings[0]) {
-			throw new Error('Malformed npm run command');
+			throw new Error('Malformed npx command');
 		}
 
 		// Note: we don't do anything clever with the values (at least for now)
@@ -25,7 +25,7 @@ function getNpxFunction(options: NpxOptions = {}) {
 		const [command, ...commandArgs] = shellQuoteParse(inputString).map((e) => e.toString());
 
 		if (!command) {
-			throw new Error('Malformed npm run command (no script provided)');
+			throw new Error('Malformed npx command (no command provided)');
 		}
 
 		const result = await pm.getRunExec(command, {
@@ -34,7 +34,7 @@ function getNpxFunction(options: NpxOptions = {}) {
 		});
 
 		if (!result) {
-			throw new Error('Failed to generate the script');
+			throw new Error('Failed to generate the exec command');
 		}
 
 		return result;

--- a/src/shortFunctions/npx.ts
+++ b/src/shortFunctions/npx.ts
@@ -1,13 +1,8 @@
 import { parse as shellQuoteParse } from 'shell-quote';
 import type { GetRunExecOptions } from '../commands';
-import type { PackageManager } from '../packageManager';
 import { getPackageManager } from '../packageManager';
 
 type NpxOptions = Partial<Omit<GetRunExecOptions, 'args'>>;
-
-// the current package manager (we use a local variable here to cache it
-// so that it not re-created for each invocation of npx)
-let pm: PackageManager | null = null;
 
 function getNpxFunction(options: NpxOptions = {}) {
 	return async function npx(strings: TemplateStringsArray, ...values: unknown[]): Promise<string> {
@@ -21,9 +16,7 @@ function getNpxFunction(options: NpxOptions = {}) {
 			return `${accStr}___${value}___${strings[index + 1]}`;
 		}, strings[0]);
 
-		if (!pm) {
-			pm = await getPackageManager();
-		}
+		const pm = await getPackageManager();
 
 		if (!pm) {
 			throw new Error('No package manager!');

--- a/src/shortFunctions/npx.ts
+++ b/src/shortFunctions/npx.ts
@@ -41,7 +41,14 @@ function getNpxFunction(options: NpxOptions = {}) {
 	};
 }
 
+/**
+ * Function to generate an exec command string for the current package manager.
+ * It accepts all the same arguments that `npx` does.
+ */
 export const npx = getNpxFunction() as ReturnType<typeof getNpxFunction> & {
+	/**
+	 * Method used to provide some options to the `npx` function.
+	 */
 	with: (options: NpxOptions) => ReturnType<typeof getNpxFunction>;
 };
 

--- a/src/shortFunctions/npx.ts
+++ b/src/shortFunctions/npx.ts
@@ -1,0 +1,37 @@
+
+import { parse as shellQuoteParse } from 'shell-quote';
+import { getPackageManager } from '../packageManager';
+
+export async function npx(strings: TemplateStringsArray, ...values: unknown[]): Promise<string>{
+  if(!strings[0]) {
+    throw new Error('Malformed npm run command');
+  }
+
+  // Note: we don't do anything clever with the values (at least for now)
+  // we're using template string literals mainly for the minimalistic api
+  const inputString = values.reduce((accStr: string, value, index) => {
+      return `${accStr}___${value}___${strings[index + 1]}`
+  }, strings[0]);
+
+  const pm = await getPackageManager();
+
+  if(!pm) {
+    throw new Error('No package manager!');
+  }
+
+  const [command, ...commandArgs] = shellQuoteParse(inputString).map(e => e.toString());
+
+  if(!command) {
+    throw new Error('Malformed npm run command (no script provided)');
+  }
+
+  const result = await pm.getRunExec(command, {
+    args: commandArgs
+  });
+
+  if(!result) {
+    throw new Error('Failed to generate the script');
+  }
+
+  return result;
+}

--- a/tests/npm_run.spec.ts
+++ b/tests/npm_run.spec.ts
@@ -52,30 +52,30 @@ suite('npm_run', () => {
 		});
 	});
 
-  describe('malformed scripts', () => {
-    test('empty', async ({ expect }) => {
-      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
-      await expect(() => npm_run``).rejects.toThrowError();
-    });
+	describe('malformed scripts', () => {
+		test('empty', async ({ expect }) => {
+			process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+			await expect(() => npm_run``).rejects.toThrowError();
+		});
 
-    test('only whitespaces', async ({ expect }) => {
-      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
-      await expect(() => npm_run`  `).rejects.toThrowError();
-    });
+		test('only whitespaces', async ({ expect }) => {
+			process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+			await expect(() => npm_run`  `).rejects.toThrowError();
+		});
 
-    test('with an positional option provided', async ({ expect }) => {
-      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
-      await expect(() => npm_run` my-script ./out`).rejects.toThrowError();
-    });
+		test('with an positional option provided', async ({ expect }) => {
+			process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+			await expect(() => npm_run` my-script ./out`).rejects.toThrowError();
+		});
 
-    test('with a flag provided', async ({ expect }) => {
-      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
-      await expect(() => npm_run` my-script --verbose`).rejects.toThrowError();
-    });
+		test('with a flag provided', async ({ expect }) => {
+			process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+			await expect(() => npm_run` my-script --verbose`).rejects.toThrowError();
+		});
 
-    test('with a multiple options provided', async ({ expect }) => {
-      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
-      await expect(() => npm_run` my-script --out ./output --verbose`).rejects.toThrowError();
-    });
-  });
+		test('with a multiple options provided', async ({ expect }) => {
+			process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+			await expect(() => npm_run` my-script --out ./output --verbose`).rejects.toThrowError();
+		});
+	});
 });

--- a/tests/npm_run.spec.ts
+++ b/tests/npm_run.spec.ts
@@ -2,35 +2,53 @@ import { npm_run } from 'src/shortFunctions/npm_run';
 import { suite, test, describe } from 'vitest';
 
 suite('npm_run', () => {
-  describe('simple script run', () => {
-    (['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
-      test(`using ${pm}`, async ({ expect }) => {
-        process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
-        const myScriptRun = await npm_run` my-script`;
-        const expectedScriptRun = {
-          npm: 'npm run my-script',
-          yarn: 'yarn my-script',
-          pnpm: 'pnpm my-script',
-          bun: 'bun my-script'
-        }[pm];
-        expect(myScriptRun).toEqual(expectedScriptRun);
-      });
-    });
-  });
+	describe('simple script run', () => {
+		(['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
+			test(`using ${pm}`, async ({ expect }) => {
+				process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
+				const myScriptRun = await npm_run` my-script`;
+				const expectedScriptRun = {
+					npm: 'npm run my-script',
+					yarn: 'yarn my-script',
+					pnpm: 'pnpm my-script',
+					bun: 'bun my-script',
+				}[pm];
+				expect(myScriptRun).toEqual(expectedScriptRun);
+			});
+		});
+	});
 
-  describe('script run with arguments', () => {
-    (['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
-      test(`using ${pm}`, async ({ expect }) => {
-        process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
-        const myScriptRun = await npm_run` my-script -- ./out --output esm`;
-        const expectedScriptRun = {
-          npm: 'npm run my-script -- ./out --output esm',
-          yarn: 'yarn my-script ./out --output esm',
-          pnpm: 'pnpm my-script ./out --output esm',
-          bun: 'bun my-script -- ./out --output esm'
-        }[pm];
-        expect(myScriptRun).toEqual(expectedScriptRun);
-      });
-    });
-  });
+	describe('script run with arguments', () => {
+		(['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
+			test(`using ${pm}`, async ({ expect }) => {
+				process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
+				const myScriptRun = await npm_run` my-script -- ./out --output esm`;
+				const expectedScriptRun = {
+					npm: 'npm run my-script -- ./out --output esm',
+					yarn: 'yarn my-script ./out --output esm',
+					pnpm: 'pnpm my-script ./out --output esm',
+					bun: 'bun my-script -- ./out --output esm',
+				}[pm];
+				expect(myScriptRun).toEqual(expectedScriptRun);
+			});
+		});
+	});
+
+	describe('script run with options and arguments', () => {
+		(['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
+			test(`using ${pm}`, async ({ expect }) => {
+				process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
+				const myScriptRun = await npm_run.with({
+					format: 'full',
+				})` my-script -- ./out --output esm`;
+				const expectedScriptRun = {
+					npm: 'npm run my-script -- ./out --output esm',
+					yarn: 'yarn run my-script ./out --output esm',
+					pnpm: 'pnpm run my-script ./out --output esm',
+					bun: 'bun run my-script -- ./out --output esm',
+				}[pm];
+				expect(myScriptRun).toEqual(expectedScriptRun);
+			});
+		});
+	});
 });

--- a/tests/npm_run.spec.ts
+++ b/tests/npm_run.spec.ts
@@ -51,4 +51,31 @@ suite('npm_run', () => {
 			});
 		});
 	});
+
+  describe('malformed scripts', () => {
+    test('empty', async ({ expect }) => {
+      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+      await expect(() => npm_run``).rejects.toThrowError();
+    });
+
+    test('only whitespaces', async ({ expect }) => {
+      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+      await expect(() => npm_run`  `).rejects.toThrowError();
+    });
+
+    test('with an positional option provided', async ({ expect }) => {
+      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+      await expect(() => npm_run` my-script ./out`).rejects.toThrowError();
+    });
+
+    test('with a flag provided', async ({ expect }) => {
+      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+      await expect(() => npm_run` my-script --verbose`).rejects.toThrowError();
+    });
+
+    test('with a multiple options provided', async ({ expect }) => {
+      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+      await expect(() => npm_run` my-script --out ./output --verbose`).rejects.toThrowError();
+    });
+  });
 });

--- a/tests/npm_run.spec.ts
+++ b/tests/npm_run.spec.ts
@@ -1,5 +1,11 @@
 import { npm_run } from 'src/shortFunctions/npm_run';
-import { suite, test, describe } from 'vitest';
+import { suite, test, describe, vi } from 'vitest';
+
+vi.mock('shellac', () => ({
+	default: {
+		env: () => () => ({ stdout: '', stderr: '' }),
+	},
+}));
 
 suite('npm_run', () => {
 	describe('simple script run', () => {

--- a/tests/npm_run.spec.ts
+++ b/tests/npm_run.spec.ts
@@ -1,0 +1,36 @@
+import { npm_run } from 'src/shortFunctions/npm_run';
+import { suite, test, describe } from 'vitest';
+
+suite('npm_run', () => {
+  describe('simple script run', () => {
+    (['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
+      test(`using ${pm}`, async ({ expect }) => {
+        process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
+        const myScriptRun = await npm_run` my-script`;
+        const expectedScriptRun = {
+          npm: 'npm run my-script',
+          yarn: 'yarn my-script',
+          pnpm: 'pnpm my-script',
+          bun: 'bun my-script'
+        }[pm];
+        expect(myScriptRun).toEqual(expectedScriptRun);
+      });
+    });
+  });
+
+  describe('script run with arguments', () => {
+    (['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
+      test(`using ${pm}`, async ({ expect }) => {
+        process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
+        const myScriptRun = await npm_run` my-script -- ./out --output esm`;
+        const expectedScriptRun = {
+          npm: 'npm run my-script -- ./out --output esm',
+          yarn: 'yarn my-script ./out --output esm',
+          pnpm: 'pnpm my-script ./out --output esm',
+          bun: 'bun my-script -- ./out --output esm'
+        }[pm];
+        expect(myScriptRun).toEqual(expectedScriptRun);
+      });
+    });
+  });
+});

--- a/tests/npx.spec.ts
+++ b/tests/npx.spec.ts
@@ -1,0 +1,36 @@
+import { npx } from 'src/shortFunctions/npx';
+import { suite, test, describe } from 'vitest';
+
+suite('npx', () => {
+  describe('simple exec command run', () => {
+    (['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
+      test(`using ${pm}`, async ({ expect }) => {
+        process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
+        const myScriptRun = await npx` pkg-command`;
+        const expectedScriptRun = {
+          npm: 'npx pkg-command',
+          yarn: 'yarn exec pkg-command',
+          pnpm: 'pnpm dlx pkg-command',
+          bun: 'bunx pkg-command'
+        }[pm];
+        expect(myScriptRun).toEqual(expectedScriptRun);
+      });
+    });
+  });
+
+  describe('exec command run with arguments', () => {
+    (['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
+      test(`using ${pm}`, async ({ expect }) => {
+        process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
+        const myScriptRun = await npx` pkg-command ./out --output esm --verbose`;
+        const expectedScriptRun = {
+          npm: 'npx pkg-command ./out --output esm --verbose',
+          yarn: 'yarn exec pkg-command -- ./out --output esm --verbose',
+          pnpm: 'pnpm dlx pkg-command ./out --output esm --verbose',
+          bun: 'bunx pkg-command ./out --output esm --verbose'
+        }[pm];
+        expect(myScriptRun).toEqual(expectedScriptRun);
+      });
+    });
+  });
+});

--- a/tests/npx.spec.ts
+++ b/tests/npx.spec.ts
@@ -2,35 +2,54 @@ import { npx } from 'src/shortFunctions/npx';
 import { suite, test, describe } from 'vitest';
 
 suite('npx', () => {
-  describe('simple exec command run', () => {
-    (['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
-      test(`using ${pm}`, async ({ expect }) => {
-        process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
-        const myScriptRun = await npx` pkg-command`;
-        const expectedScriptRun = {
-          npm: 'npx pkg-command',
-          yarn: 'yarn exec pkg-command',
-          pnpm: 'pnpm dlx pkg-command',
-          bun: 'bunx pkg-command'
-        }[pm];
-        expect(myScriptRun).toEqual(expectedScriptRun);
-      });
-    });
-  });
+	describe('simple exec command run', () => {
+		(['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
+			test(`using ${pm}`, async ({ expect }) => {
+				process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
+				const myScriptRun = await npx` pkg-command`;
+				const expectedScriptRun = {
+					npm: 'npx pkg-command',
+					yarn: 'yarn exec pkg-command',
+					pnpm: 'pnpm dlx pkg-command',
+					bun: 'bunx pkg-command',
+				}[pm];
+				expect(myScriptRun).toEqual(expectedScriptRun);
+			});
+		});
+	});
 
-  describe('exec command run with arguments', () => {
-    (['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
-      test(`using ${pm}`, async ({ expect }) => {
-        process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
-        const myScriptRun = await npx` pkg-command ./out --output esm --verbose`;
-        const expectedScriptRun = {
-          npm: 'npx pkg-command ./out --output esm --verbose',
-          yarn: 'yarn exec pkg-command -- ./out --output esm --verbose',
-          pnpm: 'pnpm dlx pkg-command ./out --output esm --verbose',
-          bun: 'bunx pkg-command ./out --output esm --verbose'
-        }[pm];
-        expect(myScriptRun).toEqual(expectedScriptRun);
-      });
-    });
-  });
+	describe('exec command run with arguments', () => {
+		(['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
+			test(`using ${pm}`, async ({ expect }) => {
+				process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
+				const myScriptRun = await npx` pkg-command ./out --output esm --verbose`;
+				const expectedScriptRun = {
+					npm: 'npx pkg-command ./out --output esm --verbose',
+					yarn: 'yarn exec pkg-command -- ./out --output esm --verbose',
+					pnpm: 'pnpm dlx pkg-command ./out --output esm --verbose',
+					bun: 'bunx pkg-command ./out --output esm --verbose',
+				}[pm];
+				expect(myScriptRun).toEqual(expectedScriptRun);
+			});
+		});
+	});
+
+	describe('exec command run with options and arguments', () => {
+		(['npm', 'yarn', 'pnpm', 'bun'] as const).forEach((pm) => {
+			test(`using ${pm}`, async ({ expect }) => {
+				process.env['npm_config_user_agent'] = `${pm}/v node/v linux`;
+				const myScriptRun = await npx.with({
+					format: 'full',
+					download: 'prefer-never',
+				})` pkg-command ./out --output esm --verbose`;
+				const expectedScriptRun = {
+					npm: 'npm exec pkg-command -- ./out --output esm --verbose',
+					yarn: 'yarn exec pkg-command -- ./out --output esm --verbose',
+					pnpm: 'pnpm exec pkg-command ./out --output esm --verbose',
+					bun: 'bun x pkg-command ./out --output esm --verbose',
+				}[pm];
+				expect(myScriptRun).toEqual(expectedScriptRun);
+			});
+		});
+	});
 });

--- a/tests/npx.spec.ts
+++ b/tests/npx.spec.ts
@@ -53,15 +53,15 @@ suite('npx', () => {
 		});
 	});
 
-  describe('malformed exec commands', () => {
-    test('empty', async ({ expect }) => {
-      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
-      await expect(() => npx``).rejects.toThrowError();
-    });
+	describe('malformed exec commands', () => {
+		test('empty', async ({ expect }) => {
+			process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+			await expect(() => npx``).rejects.toThrowError();
+		});
 
-    test('only white-spaces', async ({ expect }) => {
-      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
-      await expect(() => npx`   `).rejects.toThrowError();
-    });
-  });
+		test('only white-spaces', async ({ expect }) => {
+			process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+			await expect(() => npx`   `).rejects.toThrowError();
+		});
+	});
 });

--- a/tests/npx.spec.ts
+++ b/tests/npx.spec.ts
@@ -15,7 +15,7 @@ suite('npx', () => {
 				const myScriptRun = await npx` pkg-command`;
 				const expectedScriptRun = {
 					npm: 'npx pkg-command',
-					yarn: 'yarn exec pkg-command',
+					yarn: 'yarn dlx pkg-command',
 					pnpm: 'pnpm dlx pkg-command',
 					bun: 'bunx pkg-command',
 				}[pm];
@@ -31,7 +31,7 @@ suite('npx', () => {
 				const myScriptRun = await npx` pkg-command ./out --output esm --verbose`;
 				const expectedScriptRun = {
 					npm: 'npx pkg-command ./out --output esm --verbose',
-					yarn: 'yarn exec pkg-command -- ./out --output esm --verbose',
+					yarn: 'yarn dlx pkg-command ./out --output esm --verbose',
 					pnpm: 'pnpm dlx pkg-command ./out --output esm --verbose',
 					bun: 'bunx pkg-command ./out --output esm --verbose',
 				}[pm];
@@ -50,7 +50,7 @@ suite('npx', () => {
 				})` pkg-command ./out --output esm --verbose`;
 				const expectedScriptRun = {
 					npm: 'npm exec pkg-command -- ./out --output esm --verbose',
-					yarn: 'yarn exec pkg-command -- ./out --output esm --verbose',
+					yarn: 'yarn exec pkg-command ./out --output esm --verbose',
 					pnpm: 'pnpm exec pkg-command ./out --output esm --verbose',
 					bun: 'bun x pkg-command ./out --output esm --verbose',
 				}[pm];

--- a/tests/npx.spec.ts
+++ b/tests/npx.spec.ts
@@ -1,5 +1,11 @@
 import { npx } from 'src/shortFunctions/npx';
-import { suite, test, describe } from 'vitest';
+import { suite, test, describe, vi } from 'vitest';
+
+vi.mock('shellac', () => ({
+	default: {
+		env: () => () => ({ stdout: '', stderr: '' }),
+	},
+}));
 
 suite('npx', () => {
 	describe('simple exec command run', () => {

--- a/tests/npx.spec.ts
+++ b/tests/npx.spec.ts
@@ -52,4 +52,16 @@ suite('npx', () => {
 			});
 		});
 	});
+
+  describe('malformed exec commands', () => {
+    test('empty', async ({ expect }) => {
+      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+      await expect(() => npx``).rejects.toThrowError();
+    });
+
+    test('only white-spaces', async ({ expect }) => {
+      process.env['npm_config_user_agent'] = `npm/v node/v linux`;
+      await expect(() => npx`   `).rejects.toThrowError();
+    });
+  });
 });


### PR DESCRIPTION
This is an idea to see if such utilities could be a nice addition to the library

You can see how they work in the README changes, please let me know what you think :slightly_smiling_face: 

> PS: the functionality should be fairly done, I haven't really put too much effort thinking of the error messages getting thrown, I figured I'd first confirm if we think that this would be a worthwhile addition :slightly_smiling_face: 